### PR TITLE
Refine reconfigure api

### DIFF
--- a/DBNetworkStack+Sourcing/ResourceDataProvider.swift
+++ b/DBNetworkStack+Sourcing/ResourceDataProvider.swift
@@ -104,35 +104,29 @@ public class ResourceDataProvider<Object>: ArrayDataProviding {
     }
     
     /**
-     Replaces the current resource with a new one. It directly triggers a reload.
-     
-     If you want to silently change the content by fetching a different resource you should `skipLoadingState: true`.
-     This prevents `ResourceDataProvider` to switch in the loding state. After content change notification gets trigged.
+     Replaces the current resource with a new one.
      
      - parameter resource: The new resource to fetch.
-     - parameter skipLoadingState: when true the loading state will be skipped. Defaults to false
      */
-    public func reconfigure(with resource: Resource<[[Object]]>, skipLoadingState: Bool = false) {
+    public func reconfigure(with resource: Resource<[[Object]]>) {
         self.resource = resource
-        load(skipLoadingState: skipLoadingState)
     }
     
     /**
-     Replaces the current resource with a new one. It directly triggers a reload.
-     
-     If you want to silently change the content by fetching a different resource you should `skipLoadingState: true`.
-     This prevents `ResourceDataProvider` to switch in the loding state. After content change notification gets trigged.
+     Replaces the current resource with a new one.
      
      - parameter resource: The new resource to fetch.
-     - parameter skipLoadingState: when true the loading state will be skipped. Defaults to false
      */
-    public func reconfigure(with resource: Resource<[Object]>, skipLoadingState: Bool = false) {
+    public func reconfigure(with resource: Resource<[Object]>) {
         let twoDimensionalResource = resource.map { [$0] }
-        reconfigure(with: twoDimensionalResource, skipLoadingState: skipLoadingState)
+        reconfigure(with: twoDimensionalResource)
     }
     
     /**
      Fetches the current resources via webservices.
+     
+     If you want to silently change the content by fetching a different resource you should `skipLoadingState: true`.
+     This prevents `ResourceDataProvider` to switch into loding state.
      
       - parameter skipLoadingState: when true the loading state will be skipped. Defaults to false.
      */

--- a/DBNetworkStack+SourcingTests/RessourceDataProviderTests.swift
+++ b/DBNetworkStack+SourcingTests/RessourceDataProviderTests.swift
@@ -76,12 +76,13 @@ class ResourceDataProviderTests: XCTestCase {
         XCTAssertEqual(networkService.requestCount, 0)
     }
     
-    func testLoadResource() {
+    func testReconfigureResource() {
         //Given
         let resource = testResource(elements: ["Result"])
         
         //When
         resourceDataProvider.reconfigure(with: resource)
+        resourceDataProvider.load()
         
         //Then
         XCTAssert(resourceDataProvider.state.isLoading)
@@ -117,7 +118,8 @@ class ResourceDataProviderTests: XCTestCase {
         let resource = testResource(elements: ["Result"])
         
         //When
-        resourceDataProvider.reconfigure(with: resource, skipLoadingState: true)
+        resourceDataProvider.reconfigure(with: resource)
+        resourceDataProvider.load(skipLoadingState: true)
         
         //Then
         XCTAssert(resourceDataProvider.state.isEmpty)
@@ -127,10 +129,12 @@ class ResourceDataProviderTests: XCTestCase {
     func testLoadSucceed() {
         //Given
         let resource = testResource(elements: ["Result"])
+        resourceDataProvider.reconfigure(with: resource)
         
         //When
-        resourceDataProvider.reconfigure(with: resource)
+        resourceDataProvider.load()
         networkService.returnSuccess()
+        
         //Then
         XCTAssert(resourceDataProvider.state.hasSucceded)
         XCTAssertEqual("Result", resourceDataProvider.contents.first?.first)
@@ -141,9 +145,11 @@ class ResourceDataProviderTests: XCTestCase {
     func testLoadError() {
         //Given
         let resource = testResource(elements: ["Result"])
+        resourceDataProvider.reconfigure(with: resource)
         
         //When
-        resourceDataProvider.reconfigure(with: resource)
+        
+        resourceDataProvider.load()
         networkService.returnError(with: .unknownError)
         
         //Then
@@ -154,9 +160,10 @@ class ResourceDataProviderTests: XCTestCase {
     func testOnNetworkRequestCanceldWithEmptyData() {
         //Given
         let resource = testResource(elements: ["Result"])
+        resourceDataProvider.reconfigure(with: resource)
         
         //When
-        resourceDataProvider.reconfigure(with: resource)
+        resourceDataProvider.load()
         networkService.returnError(with: .cancelled)
         
         //Then

--- a/DBNetworkStack+SourcingTests/RessourceDataProviderTests.swift
+++ b/DBNetworkStack+SourcingTests/RessourceDataProviderTests.swift
@@ -25,11 +25,13 @@ import DBNetworkStackSourcing
 import DBNetworkStack
 import Sourcing
 
-func testResource<T>(elements: [T]) -> Resource<Array<T>> {
-    let url: URL! = URL(string: "bahn.de")
-    let request = URLRequest(url: url)
-    
-    return Resource(request: request, parse: { _ in return elements })
+extension Resource {
+    static func mockWith(result: Model) -> Resource<Model> {
+        let url: URL! = URL(string: "bahn.de")
+        let request = URLRequest(url: url)
+        
+        return Resource(request: request, parse: { _ in return result })
+    }
 }
 
 class ResourceDataProviderTests: XCTestCase {
@@ -66,7 +68,7 @@ class ResourceDataProviderTests: XCTestCase {
     
     func testInitWithResource() {
         //Given
-        let resource = testResource(elements: ["Result"])
+        let resource = Resource.mockWith(result: ["Result"])
         
         //When
         let resourceDataProvider = ResourceDataProvider(resource: resource, networkService: networkService, whenStateChanges: { _ in })
@@ -78,7 +80,7 @@ class ResourceDataProviderTests: XCTestCase {
     
     func testReconfigureResource() {
         //Given
-        let resource = testResource(elements: ["Result"])
+        let resource = Resource.mockWith(result: ["Result"])
         
         //When
         resourceDataProvider.reconfigure(with: resource)
@@ -91,7 +93,7 @@ class ResourceDataProviderTests: XCTestCase {
     
     func testLoadTransformedResource() {
         //Given
-        let resource = testResource(elements: ["Result"])
+        let resource = Resource.mockWith(result: ["Result"])
         
         //When
         let resourceDataProvider = ResourceDataProvider(resource: resource, networkService: networkService, whenStateChanges: { _ in })
@@ -115,7 +117,7 @@ class ResourceDataProviderTests: XCTestCase {
     
     func testLoadResource_skipLoadingState() {
         //Given
-        let resource = testResource(elements: ["Result"])
+        let resource = Resource.mockWith(result: ["Result"])
         
         //When
         resourceDataProvider.reconfigure(with: resource)
@@ -128,7 +130,7 @@ class ResourceDataProviderTests: XCTestCase {
     
     func testLoadSucceed() {
         //Given
-        let resource = testResource(elements: ["Result"])
+        let resource = Resource.mockWith(result: ["Result"])
         resourceDataProvider.reconfigure(with: resource)
         
         //When
@@ -144,7 +146,7 @@ class ResourceDataProviderTests: XCTestCase {
     
     func testLoadError() {
         //Given
-        let resource = testResource(elements: ["Result"])
+        let resource = Resource.mockWith(result: ["Result"])
         resourceDataProvider.reconfigure(with: resource)
         
         //When
@@ -159,7 +161,7 @@ class ResourceDataProviderTests: XCTestCase {
     
     func testOnNetworkRequestCanceldWithEmptyData() {
         //Given
-        let resource = testResource(elements: ["Result"])
+        let resource = Resource.mockWith(result: ["Result"])
         resourceDataProvider.reconfigure(with: resource)
         
         //When


### PR DESCRIPTION
After reconfiguring the data provider one need to call load explicitly. This is changed to be consistent to the initializers of `ResourceDataProvider`